### PR TITLE
Added alerts endpoint

### DIFF
--- a/src/main/java/org/emmanuel/co2/monitoring/domain/repository/SensorAlertRepository.java
+++ b/src/main/java/org/emmanuel/co2/monitoring/domain/repository/SensorAlertRepository.java
@@ -2,8 +2,12 @@ package org.emmanuel.co2.monitoring.domain.repository;
 
 import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
 
+import java.util.List;
+
 public interface SensorAlertRepository extends ActiveBySensorFinder<SensorAlert> {
 
     SensorAlert save(SensorAlert alert);
+
+    List<SensorAlert> findAllBySensorId(String sensorId);
 
 }

--- a/src/main/java/org/emmanuel/co2/monitoring/domain/repository/inMemory/InMemorySensorAlertRepository.java
+++ b/src/main/java/org/emmanuel/co2/monitoring/domain/repository/inMemory/InMemorySensorAlertRepository.java
@@ -4,6 +4,7 @@ import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
 import org.emmanuel.co2.monitoring.domain.repository.SensorAlertRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -12,6 +13,11 @@ public class InMemorySensorAlertRepository extends InMemoryRepository<SensorAler
     @Override
     public SensorAlert save(SensorAlert alert) {
         return super.save(alert);
+    }
+
+    @Override
+    public List<SensorAlert> findAllBySensorId(String sensorId) {
+        return super.findAll(a -> a.getSensor().getId().equals(sensorId));
     }
 
     @Override

--- a/src/main/java/org/emmanuel/co2/monitoring/service/DefaultSensorAlertService.java
+++ b/src/main/java/org/emmanuel/co2/monitoring/service/DefaultSensorAlertService.java
@@ -1,0 +1,20 @@
+package org.emmanuel.co2.monitoring.service;
+
+import lombok.RequiredArgsConstructor;
+import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
+import org.emmanuel.co2.monitoring.domain.repository.SensorAlertRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultSensorAlertService implements SensorAlertService {
+
+    private final SensorAlertRepository sensorAlertRepository;
+
+    @Override
+    public List<SensorAlert> getAlerts(String sensorId) {
+        return this.sensorAlertRepository.findAllBySensorId(sensorId);
+    }
+}

--- a/src/main/java/org/emmanuel/co2/monitoring/service/SensorAlertService.java
+++ b/src/main/java/org/emmanuel/co2/monitoring/service/SensorAlertService.java
@@ -1,0 +1,11 @@
+package org.emmanuel.co2.monitoring.service;
+
+import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
+
+import java.util.List;
+
+public interface SensorAlertService {
+
+    List<SensorAlert> getAlerts(String sensorId);
+
+}

--- a/src/test/java/org/emmanuel/co2/monitoring/business/stateRule/BaseSensorStateRuleTestCase.java
+++ b/src/test/java/org/emmanuel/co2/monitoring/business/stateRule/BaseSensorStateRuleTestCase.java
@@ -28,7 +28,7 @@ public abstract class BaseSensorStateRuleTestCase {
         var now = OffsetDateTime.now();
         var warning = SensorWarning.create(sensor, now);
 
-        IntStream.rangeClosed(1, SensorThresholdConfiguration.MAX_ATTEMPTS.value() - 1)
+        IntStream.range(1, SensorThresholdConfiguration.MAX_ATTEMPTS.value())
                 .forEach(i -> warning.addHigherRead(new SensorMeasurement(sensor, i, now)));
 
         return new CurrentSensorState(sensor, SensorState.WARN, warning);

--- a/src/test/java/org/emmanuel/co2/monitoring/domain/repository/inMemory/InMemorySensorAlertRepositoryTest.java
+++ b/src/test/java/org/emmanuel/co2/monitoring/domain/repository/inMemory/InMemorySensorAlertRepositoryTest.java
@@ -3,9 +3,14 @@ package org.emmanuel.co2.monitoring.domain.repository.inMemory;
 import org.emmanuel.co2.monitoring.domain.entity.Sensor;
 import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
 import org.emmanuel.co2.monitoring.domain.repository.ActiveBySensorFinder;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class InMemorySensorAlertRepositoryTest extends ActiveBySensorFinderTestCase<SensorAlert> {
 
@@ -40,5 +45,22 @@ class InMemorySensorAlertRepositoryTest extends ActiveBySensorFinderTestCase<Sen
         this.repository = new InMemorySensorAlertRepository();
     }
 
+    @Test
+    void shouldFindAllAlerts() {
+        var sensor = new Sensor("123");
+        var quantity = 5;
+        saveListOfAlertsOnDatabase(sensor, quantity);
+
+        var alerts = this.repository.findAllBySensorId(sensor.getId());
+        assertEquals(quantity, alerts.size());
+    }
+
+    private void saveListOfAlertsOnDatabase(Sensor sensor, int quantity) {
+        IntStream.rangeClosed(1, quantity).forEach(i -> {
+            var now = OffsetDateTime.now();
+            var alert = SensorAlert.create(sensor, now);
+            this.repository.save(alert);
+        });
+    }
 
 }

--- a/src/test/java/org/emmanuel/co2/monitoring/service/DefaultSensorAlertServiceTest.java
+++ b/src/test/java/org/emmanuel/co2/monitoring/service/DefaultSensorAlertServiceTest.java
@@ -1,0 +1,56 @@
+package org.emmanuel.co2.monitoring.service;
+
+import org.emmanuel.co2.monitoring.domain.entity.Sensor;
+import org.emmanuel.co2.monitoring.domain.entity.SensorAlert;
+import org.emmanuel.co2.monitoring.domain.repository.SensorAlertRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultSensorAlertServiceTest {
+
+    private SensorAlertRepository repository;
+    private DefaultSensorAlertService service;
+
+    @BeforeEach
+    void setUp() {
+        this.repository = mock(SensorAlertRepository.class);
+        this.service = new DefaultSensorAlertService(this.repository);
+    }
+
+    @Test
+    void getAlerts() {
+        var sensor = new Sensor("123");
+        var quantity = 50;
+        givenAlertsForSensorOnDatabase(sensor, quantity);
+
+        var alerts = this.service.getAlerts(sensor.getId());
+
+        assertEquals(quantity, alerts.size());
+    }
+
+    private void givenAlertsForSensorOnDatabase(Sensor sensor, int quantity) {
+        when(this.repository.findAllBySensorId(sensor.getId()))
+                .thenReturn(mockAlertList(sensor, quantity));
+    }
+
+    private List<SensorAlert> mockAlertList(Sensor sensor, int quantity) {
+        IntFunction<SensorAlert> mapper = (i) -> {
+            var now = OffsetDateTime.now();
+            return SensorAlert.create(sensor, now, now);
+        };
+
+        return IntStream.rangeClosed(1, quantity)
+                .mapToObj(mapper)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
In this PR I've added the alert endpoint. The endpoint will return an array with all alerts for a given sensor or an empty array with there is no alert associated with the sensor.

**Endpoint definition:**

Path: `/{sensorId}/alerts`

Example payload:

```json
[
  {
    "startTime": "2020-06-21T20:25:00Z",
    "endTime": "2020-06-21T20:25:00Z",
    "measurement1": 2500,
    "measurement2": 2500,
    "measurement3": 2500
  }
]
```